### PR TITLE
Vercel build error fix

### DIFF
--- a/dist/src/index.d.ts
+++ b/dist/src/index.d.ts
@@ -1,4 +1,4 @@
 export * from './generated';
 export * from './errors';
-export * from './parser';
+export * from './Parser';
 export * from './utils/log';

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -16,6 +16,6 @@ var __exportStar = (this && this.__exportStar) || function(m, exports) {
 Object.defineProperty(exports, "__esModule", { value: true });
 __exportStar(require("./generated"), exports);
 __exportStar(require("./errors"), exports);
-__exportStar(require("./parser"), exports);
+__exportStar(require("./Parser"), exports);
 __exportStar(require("./utils/log"), exports);
 //# sourceMappingURL=index.js.map


### PR DESCRIPTION
Vercel wouldn't build without changing `./parser` import to `./Parser`
![image](https://user-images.githubusercontent.com/15003968/191372477-1729d6d2-b1b1-46b5-9a79-84d125fdd5d6.png)